### PR TITLE
Fix deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -xe
+#!/bin/sh
+set -xe
 
 DEPLOY_FOLDER="deploy"
 DEPLOY_BRANCH="build"

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,7 @@ git push --tag --force origin-pages || exit 1
 git clone -b $DEPLOY_BRANCH --single-branch "https://${GH_REPO}" $DEPLOY_FOLDER
 
 # Clean up files from last build(except .git)
-find ./$DEPLOY_FOLDER/* ! -path "./${DEPLOY_FOLDER}/.git/*" ! -name ".git" | xargs rm -rf
+find ./$DEPLOY_FOLDER/{.??,}* ! -path "./${DEPLOY_FOLDER}/.git/*" ! -name ".git" | xargs rm -rf
 
 # Copy built files
 cp -R ./build/. ./$DEPLOY_FOLDER

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,9 +3354,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-kendo-ui-core@telerik/kendo-ui-core#2014.3.1316:
-  version "1.0.0"
-  resolved "https://codeload.github.com/telerik/kendo-ui-core/tar.gz/11435985186a69b4a78b608ce52a1492cd4af0be"
+kendo-ui-core@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/kendo-ui-core/-/kendo-ui-core-1.0.2.tgz#c8a8d5476518b189b5da5ee14fce6a23551fc796"
 
 kind-of@^3.0.2:
   version "3.2.2"


### PR DESCRIPTION
- Fix shebang of `deploy.sh`.
- Clean up `deploy/` folder including dot files, previously `*` will only remove all non-dot files.
- Update dependency of `kendo-ui-core` in yarn lockfile.